### PR TITLE
fix: format billed quantity in UBL with four decimal places

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -622,7 +622,7 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteStartElement("cbc", "CreditedQuantity");
             }
             Writer.WriteAttributeString("unitCode", tradeLineItem.UnitCode.EnumToString());
-            Writer.WriteValue(_formatDecimal(tradeLineItem.BilledQuantity));
+            Writer.WriteValue(_formatDecimal(tradeLineItem.BilledQuantity, 4));
             Writer.WriteEndElement(); // !InvoicedQuantity || CreditedQuantity
 
             Writer.WriteStartElement("cbc", "LineExtensionAmount");


### PR DESCRIPTION
To ensure consistency between CII and UBL, the billed quantity in UBL will now be formatted with four decimal places.