### PR TITLE
fix: use TradingBusinessName for PartyName in UBL writer

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -937,11 +937,11 @@ namespace s2industries.ZUGFeRD
                     }
                 }
 
-                if (!string.IsNullOrWhiteSpace(party.Name))
+                if (!string.IsNullOrWhiteSpace(party.SpecifiedLegalOrganization.TradingBusinessName))
                 {
                     writer.WriteStartElement("cac", "PartyName");
                     writer.WriteStartElement("cbc", "Name");
-                    writer.WriteValue(party.Name);
+                    writer.WriteValue(party.SpecifiedLegalOrganization.TradingBusinessName);
                     writer.WriteEndElement();//!Name
                     writer.WriteEndElement();//!PartyName
                 }


### PR DESCRIPTION
Updated logic to retrieve `TradingBusinessName` from `SpecifiedLegalOrganization` for `PartyName` element, ensuring accurate data mapping and compliance with UBL specifications.