### PR TITLE
fix: refine handling of trade allowance charges in UBL writer

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -453,7 +453,7 @@ namespace s2industries.ZUGFeRD
             foreach (TradeCharge charge in descriptor.GetTradeCharges())
             {
                 _WriteDocumentLevelAllowanceCharges(Writer, charge);
-            } // !foreach(charge)            
+            } // !foreach(charge)
             #endregion
 
             // Tax Total
@@ -532,7 +532,7 @@ namespace s2industries.ZUGFeRD
 
             if ((tradeAllowanceCharge is TradeAllowance allowance) && (allowance.ReasonCode != null))
             {
-                Writer.WriteStartElement("cbc", "AllowanceChargeReasonCode"); // BT-97                
+                Writer.WriteStartElement("cbc", "AllowanceChargeReasonCode"); // BT-97
                 string s = EnumExtensions.EnumToString<AllowanceReasonCodes>(allowance.ReasonCode);
                 Writer.WriteValue(EnumExtensions.EnumToString<AllowanceReasonCodes>(allowance.ReasonCode));
                 Writer.WriteEndElement();
@@ -582,7 +582,7 @@ namespace s2industries.ZUGFeRD
             Writer.WriteEndElement(); // cac:TaxScheme
             Writer.WriteEndElement(); // cac:TaxCategory
 
-            Writer.WriteEndElement(); // !AllowanceCharge()            
+            Writer.WriteEndElement(); // !AllowanceCharge()
         } // !_WriteDocumentLevelAllowanceCharges()
 
 
@@ -659,8 +659,17 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteStartElement("cac", "AllowanceCharge");
                 Writer.WriteElementString("cbc", "ChargeIndicator",
                     specifiedTradeAllowanceCharge.ChargeIndicator ? "true" : "false"); // BG-28-0
-                Writer.WriteOptionalElementString("cbc", "AllowanceChargeReasonCode",
-                    specifiedTradeAllowanceCharge.ReasonCode.GetDescriptionAttribute()); // BT-140, BT-145
+                
+                if ((specifiedTradeAllowanceCharge is TradeAllowance allowance) && (allowance.ReasonCode != null))
+                {
+                    Writer.WriteOptionalElementString("cbc", "AllowanceChargeReasonCode",
+                        EnumExtensions.EnumToString(allowance.ReasonCode)); // BT-140, BT-145
+                }
+                else if ((specifiedTradeAllowanceCharge is TradeCharge charge) && (charge.ReasonCode != null))
+                {
+                    Writer.WriteOptionalElementString("cbc", "AllowanceChargeReasonCode",
+                        EnumExtensions.EnumToString(charge.ReasonCode)); // BT-140, BT-145
+                }
                 Writer.WriteOptionalElementString("cbc", "AllowanceChargeReason",
                     specifiedTradeAllowanceCharge.Reason); // BT-139, BT-144
 
@@ -753,7 +762,7 @@ namespace s2industries.ZUGFeRD
                     else
                     {
                         Writer.WriteElementString("cbc", "ChargeIndicator", "true");
-                    }                    
+                    }
 
                     Writer.WriteStartElement("cbc", "Amount"); // BT-147
                     Writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
@@ -937,7 +946,7 @@ namespace s2industries.ZUGFeRD
                     }
                 }
 
-                if (!string.IsNullOrWhiteSpace(party.SpecifiedLegalOrganization.TradingBusinessName))
+                if (party.SpecifiedLegalOrganization != null && !string.IsNullOrWhiteSpace(party.SpecifiedLegalOrganization.TradingBusinessName))
                 {
                     writer.WriteStartElement("cac", "PartyName");
                     writer.WriteStartElement("cbc", "Name");


### PR DESCRIPTION
Enhanced logic for processing `AllowanceChargeReasonCode` in both trade allowances and trade charges. Improved null checks and corrected conditional handling to ensure accurate serialization.